### PR TITLE
Replace deprecated sklearn.externals.six

### DIFF
--- a/semester_1/Machine_Learning/Lecture_3-DecisionTrees/Lecture_3-DecisionTrees.ipynb
+++ b/semester_1/Machine_Learning/Lecture_3-DecisionTrees/Lecture_3-DecisionTrees.ipynb
@@ -132,7 +132,7 @@
     }
    ],
    "source": [
-    "from sklearn.externals.six import StringIO  \n",
+    "from six import StringIO\n",
     "from IPython.display import Image  \n",
     "from sklearn.tree import export_graphviz\n",
     "import pydotplus\n",


### PR DESCRIPTION
The import used does not work with latest `scikit-learn`

https://github.com/scikit-learn/scikit-learn/pull/12916